### PR TITLE
Implement dynamic MCP gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,131 @@
 # CHATGPT_GO
 
-A Go-based API Gateway that automatically discovers local microservices (MCP Servers) and exposes them to a custom ChatGPT GPT via a single, dynamic OpenAPI schema.
+A Go-based gateway that discovers locally installed MCP (Model Context Protocol) servers and exposes them to a single custom ChatGPT GPT through an automatically generated OpenAPI schema. Drop a YAML file describing a local service into the `mcp_servers` directory and the gateway will immediately proxy requests to it and update the schema imported by your GPT.
 
-## How it Works
+## Features
 
-1.  The application runs as a local server, acting as a proxy.
-2.  It watches the `/mcp_servers` directory for new service configuration files.
-3.  When a new service is detected, the gateway dynamically generates an `openapi.json` schema that includes the new service's endpoints.
-4.  This gateway is exposed to the internet using a tunneling tool like `ngrok`.
-5.  A single custom GPT is configured to use the gateway's `openapi.json` from the public `ngrok` URL.
-6.  When an action is invoked in ChatGPT, the request hits the gateway, which then proxies it to the appropriate local MCP server.
-
-This allows developers to add and remove local services that are accessible to ChatGPT without ever needing to reconfigure the GPT itself.
+- ⚙️ **Automatic discovery** – watches a directory for new/updated YAML service definitions.
+- 📄 **Dynamic OpenAPI generation** – serves a consolidated `openapi.json` that always reflects the active MCP servers.
+- 🔁 **Reverse proxy** – forwards action requests from ChatGPT to the correct local service, preserving headers and query parameters.
+- 🏷️ **Service metadata** – annotates each operation with vendor extensions (`x-service-name`, `x-service-address`) so you can trace requests back to their source.
+- 🛡️ **CORS friendly** – responds to `OPTIONS` requests and allows cross-origin calls, making tunnelling tools like ngrok painless.
 
 ## Getting Started
 
-### 1. Install Dependencies
+### Prerequisites
 
-Run the following command in the project root to download the necessary Go modules.
-```sh
+- Go 1.21+
+- (Optional) [ngrok](https://ngrok.com/) or another tunnelling utility to expose the gateway to the internet.
+
+### 1. Fetch dependencies
+
+```bash
 go mod tidy
 ```
 
-### 2. Run the Example Services
+### 2. Start the example MCP servers (optional but recommended)
 
-Open two separate terminal windows to run the mock "MCP Servers".
+These mock services live under `examples/` and mirror the sample YAML definitions.
 
-**Terminal 1 (Weather Service):**
-```sh
-go run ./examples/weather_service/main.go
+```bash
+# Terminal 1 – Weather service
+cd examples/weather_service
+go run .
 ```
 
-**Terminal 2 (Todo Service):**
-```sh
-go run ./examples/todo_service/main.go
+```bash
+# Terminal 2 – Todo service
+cd examples/todo_service
+go run .
 ```
 
-### 3. Run the Gateway
+Both services listen on `localhost` ports (`9001` and `9002`). Feel free to swap in your own MCP servers using the same addresses.
 
-In a third terminal, run the main gateway application.
-```sh
-go run main.go
+### 3. Run the gateway
+
+```bash
+go run .
 ```
 
-### 4. Expose to the Internet
+By default the gateway listens on `:8080` and watches the `./mcp_servers` directory. The first run ships with two sample YAML files:
 
-The gateway runs on `localhost:8080`. To make it accessible to ChatGPT, you need to expose it using a tunneling service like `ngrok`.
+- `mcp_servers/weather.yaml`
+- `mcp_servers/todo.yaml`
 
-**Terminal 4 (ngrok):**
-```sh
+Add, edit, or remove YAML files in that directory and the gateway will reload automatically—no restart required.
+
+### 4. (Optional) Expose the gateway to ChatGPT
+
+Use a tunnelling service to make the local server reachable from ChatGPT. For example with ngrok:
+
+```bash
 ngrok http 8080
 ```
-`ngrok` will give you a public URL (e.g., `https://<random-id>.ngrok-free.app`).
 
-### 5. Configure ChatGPT
+Take note of the public URL (e.g. `https://<random-id>.ngrok-free.app`).
 
-1.  Create a new GPT in ChatGPT.
-2.  Go to **Configure -> Actions -> Create new action**.
-3.  Select **Import from URL**.
-4.  Paste the URL to your gateway's OpenAPI schema: `https://<random-id>.ngrok-free.app/openapi.json`.
-5.  Follow the prompts to import the actions.
+### 5. Configure your custom GPT
 
-You can now chat with your GPT and invoke actions like "What is the weather in London?" or "What's on my todo list?". If you add a new `.yaml` file to the `mcp_servers` directory, the gateway will automatically pick it up!
+1. Create or edit a GPT at [chat.openai.com](https://chat.openai.com/).
+2. Open **Configure → Actions** and choose **Import from URL**.
+3. Paste the gateway schema URL: `https://<ngrok-id>.ngrok-free.app/openapi.json`.
+4. Save the GPT. Actions are now routed to whatever MCP servers are described in `mcp_servers/`.
+
+## Defining Services
+
+Service definitions are plain YAML. Each file represents one MCP server and can contain multiple endpoints. Example (`mcp_servers/weather.yaml`):
+
+```yaml
+serviceName: weather
+serviceAddress: http://localhost:9001
+description: "A service that returns the current weather for a city."
+endpoints:
+  - path: /weather/{city}
+    method: GET
+    description: "Get the current weather for a specific city."
+    operationId: getWeatherForCity
+    parameters:
+      - name: city
+        in: path
+        description: "City to look up."
+        schema:
+          type: string
+```
+
+Endpoints support:
+
+- Path, method, description, and optional `operationId`.
+- Path and query parameters (path parameters are auto-marked as required).
+- Optional request bodies with arbitrary JSON schema snippets.
+
+Add as many YAML files as you need; the gateway merges them into a single OpenAPI document, tagging each operation with the originating service.
+
+## Configuration Reference
+
+| Option | Description | Default |
+| ------ | ----------- | ------- |
+| `CHATGPT_GATEWAY_CONFIG` | Directory to watch for YAML files. | `./mcp_servers` |
+| `CHATGPT_GATEWAY_ADDR` | Exact address (`host:port`) for the HTTP server. | *(unset)* |
+| `CHATGPT_GATEWAY_PORT` | Port (or `host:port`) if `CHATGPT_GATEWAY_ADDR` is unset. | `8080` |
+| `--config` | CLI flag alternative to `CHATGPT_GATEWAY_CONFIG`. | `./mcp_servers` |
+| `--addr` | CLI flag alternative to `CHATGPT_GATEWAY_ADDR`. | `:8080` |
+
+CLI flags override environment variables.
+
+## How the Gateway Works
+
+1. Service YAML files are parsed into in-memory definitions.
+2. The gateway builds a route table (method + path → service).
+3. On every HTTP request (except `/openapi.json`), it finds the matching route and proxies the call to the service's `serviceAddress`.
+4. The `/openapi.json` endpoint returns a merged OpenAPI 3.1 schema that ChatGPT uses for action discovery.
+
+Any file creation, modification, removal, or rename inside the config directory triggers a reload and schema regeneration.
+
+## Development Tips
+
+- Enable verbose logging by running the gateway directly (`go run .`)—you'll see proxy activity and file watcher events.
+- Want to model a new MCP server? Copy one of the sample YAML files and adjust the metadata, endpoints, and address.
+- You can inspect the generated OpenAPI document locally at [http://localhost:8080/openapi.json](http://localhost:8080/openapi.json).
+- The helper services under `examples/` are intentionally simple and stateless, making them easy to adapt or replace.
+
+Happy hacking! Drop your services in `mcp_servers/` and they instantly become available to your GPT under Developer Mode.

--- a/examples/todo_service/main.go
+++ b/examples/todo_service/main.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+)
+
+type todo struct {
+	ID        int       `json:"id"`
+	Task      string    `json:"task"`
+	Completed bool      `json:"completed"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+type createTodoRequest struct {
+	Task string `json:"task"`
+}
+
+var (
+	todos  = []todo{}
+	nextID = 1
+	mu     sync.Mutex
+)
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/todos", todosHandler)
+
+	srv := &http.Server{
+		Addr:              ":9002",
+		Handler:           logRequests(mux),
+		ReadHeaderTimeout: 5 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       30 * time.Second,
+	}
+
+	log.Printf("[todo] listening on %s", srv.Addr)
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("todo service failed: %v", err)
+	}
+}
+
+func todosHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		handleListTodos(w, r)
+	case http.MethodPost:
+		handleCreateTodo(w, r)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func handleListTodos(w http.ResponseWriter, _ *http.Request) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(todos); err != nil {
+		log.Printf("[todo] failed to encode todos: %v", err)
+	}
+}
+
+func handleCreateTodo(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+	var payload createTodoRequest
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "invalid JSON payload", http.StatusBadRequest)
+		return
+	}
+	if payload.Task == "" {
+		http.Error(w, "task is required", http.StatusBadRequest)
+		return
+	}
+
+	mu.Lock()
+	todo := todo{
+		ID:        nextID,
+		Task:      payload.Task,
+		Completed: false,
+		CreatedAt: time.Now().UTC(),
+	}
+	nextID++
+	todos = append(todos, todo)
+	mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	if err := json.NewEncoder(w).Encode(todo); err != nil {
+		log.Printf("[todo] failed to encode created todo: %v", err)
+	}
+}
+
+type loggingResponseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (lrw *loggingResponseWriter) WriteHeader(statusCode int) {
+	lrw.status = statusCode
+	lrw.ResponseWriter.WriteHeader(statusCode)
+}
+
+func logRequests(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lrw := &loggingResponseWriter{ResponseWriter: w, status: http.StatusOK}
+		start := time.Now()
+		next.ServeHTTP(lrw, r)
+		log.Printf("[todo] %s %s -> %d (%s)", r.Method, r.URL.Path, lrw.status, time.Since(start))
+	})
+}

--- a/examples/weather_service/main.go
+++ b/examples/weather_service/main.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/rand"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type forecast struct {
+	City        string `json:"city"`
+	Temperature string `json:"temperature"`
+	Condition   string `json:"condition"`
+	UpdatedAt   string `json:"updatedAt"`
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/weather/", weatherHandler)
+
+	srv := &http.Server{
+		Addr:              ":9001",
+		Handler:           logRequests(mux),
+		ReadHeaderTimeout: 5 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       30 * time.Second,
+	}
+
+	log.Printf("[weather] listening on %s", srv.Addr)
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("weather service failed: %v", err)
+	}
+}
+
+func weatherHandler(w http.ResponseWriter, r *http.Request) {
+	citySlug := strings.TrimPrefix(r.URL.Path, "/weather/")
+	citySlug = strings.Trim(citySlug, "/")
+	if citySlug == "" {
+		http.Error(w, "city is required", http.StatusBadRequest)
+		return
+	}
+
+	conditions := []string{"Sunny", "Partly Cloudy", "Overcast", "Rain", "Thunderstorms", "Snow"}
+	condition := conditions[rand.Intn(len(conditions))]
+	temperature := fmt.Sprintf("%d°C", rand.Intn(15)+10)
+
+	forecast := forecast{
+		City:        prettifyCity(citySlug),
+		Temperature: temperature,
+		Condition:   condition,
+		UpdatedAt:   time.Now().UTC().Format(time.RFC3339),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(forecast); err != nil {
+		log.Printf("[weather] failed to encode response: %v", err)
+	}
+}
+
+func prettifyCity(slug string) string {
+	parts := strings.FieldsFunc(slug, func(r rune) bool {
+		return r == '-' || r == '_' || r == ' '
+	})
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		lower := strings.ToLower(part)
+		parts[i] = strings.ToUpper(lower[:1]) + lower[1:]
+	}
+	return strings.Join(parts, " ")
+}
+
+type loggingResponseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (lrw *loggingResponseWriter) WriteHeader(statusCode int) {
+	lrw.status = statusCode
+	lrw.ResponseWriter.WriteHeader(statusCode)
+}
+
+func logRequests(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lrw := &loggingResponseWriter{ResponseWriter: w, status: http.StatusOK}
+		start := time.Now()
+		next.ServeHTTP(lrw, r)
+		log.Printf("[weather] %s %s -> %d (%s)", r.Method, r.URL.Path, lrw.status, time.Since(start))
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+require golang.org/x/sys v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
+github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
+golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
+golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -1,0 +1,371 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+var ErrNoMatchingRoute = errors.New("no matching route found")
+
+type Gateway struct {
+	mu            sync.RWMutex
+	services      map[string]*Service
+	fileToService map[string]string
+	routes        map[string][]*route
+	client        *http.Client
+	configDir     string
+}
+
+func New(configDir string) (*Gateway, error) {
+	absDir, err := filepath.Abs(configDir)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(absDir, 0o755); err != nil {
+		return nil, fmt.Errorf("unable to create config directory %s: %w", absDir, err)
+	}
+	g := &Gateway{
+		services:      make(map[string]*Service),
+		fileToService: make(map[string]string),
+		routes:        make(map[string][]*route),
+		client: &http.Client{
+			Timeout: 60 * time.Second,
+		},
+		configDir: absDir,
+	}
+	return g, nil
+}
+
+func (g *Gateway) ConfigDir() string {
+	return g.configDir
+}
+
+func (g *Gateway) LoadExisting() error {
+	entries, err := os.ReadDir(g.configDir)
+	if err != nil {
+		return fmt.Errorf("unable to read config directory: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(g.configDir, entry.Name())
+		if !isYAMLFile(path) {
+			continue
+		}
+		g.loadService(path)
+	}
+	return nil
+}
+
+func (g *Gateway) Watch(ctx context.Context) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	if err := watcher.Add(g.configDir); err != nil {
+		watcher.Close()
+		return fmt.Errorf("unable to watch directory %s: %w", g.configDir, err)
+	}
+
+	go func() {
+		defer watcher.Close()
+		for {
+			select {
+			case event := <-watcher.Events:
+				g.handleWatcherEvent(event)
+			case err := <-watcher.Errors:
+				if err != nil {
+					log.Printf("[gateway] watcher error: %v", err)
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (g *Gateway) handleWatcherEvent(event fsnotify.Event) {
+	if event.Name == "" {
+		return
+	}
+	if !isYAMLFile(event.Name) {
+		if event.Op&fsnotify.Rename != 0 {
+			go g.refreshDirectory()
+		}
+		return
+	}
+	if event.Op&fsnotify.Rename != 0 {
+		g.removeService(event.Name)
+		go g.refreshDirectory()
+		return
+	}
+	if event.Op&fsnotify.Remove != 0 {
+		g.removeService(event.Name)
+		return
+	}
+	if event.Op&(fsnotify.Write|fsnotify.Create) != 0 {
+		go func(path string) {
+			time.Sleep(200 * time.Millisecond)
+			g.loadService(path)
+		}(event.Name)
+	}
+}
+
+func (g *Gateway) loadService(path string) {
+	svc, err := LoadService(path)
+	if err != nil {
+		log.Printf("[gateway] failed to load service from %s: %v", filepath.Base(path), err)
+		return
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if oldName, ok := g.fileToService[path]; ok && oldName != svc.Name {
+		delete(g.services, oldName)
+	}
+	g.services[svc.Name] = svc
+	g.fileToService[path] = svc.Name
+	g.rebuildRoutesLocked()
+
+	log.Printf("[gateway] loaded service %q from %s", svc.Name, filepath.Base(path))
+}
+
+func (g *Gateway) removeService(path string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	name, ok := g.fileToService[path]
+	if !ok {
+		return
+	}
+	delete(g.fileToService, path)
+	delete(g.services, name)
+	g.rebuildRoutesLocked()
+	log.Printf("[gateway] removed service %q (source %s)", name, filepath.Base(path))
+}
+
+func (g *Gateway) rebuildRoutesLocked() {
+	routes := make(map[string][]*route)
+	for _, svc := range g.services {
+		for _, ep := range svc.Endpoints {
+			rt, err := newRoute(svc, ep)
+			if err != nil {
+				log.Printf("[gateway] skipping endpoint %s %s: %v", ep.Method, ep.Path, err)
+				continue
+			}
+			method := strings.ToUpper(ep.Method)
+			routes[method] = append(routes[method], rt)
+		}
+	}
+	g.routes = routes
+}
+
+func (g *Gateway) refreshDirectory() {
+	time.Sleep(300 * time.Millisecond)
+	entries, err := os.ReadDir(g.configDir)
+	if err != nil {
+		log.Printf("[gateway] failed to refresh directory: %v", err)
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(g.configDir, entry.Name())
+		if !isYAMLFile(path) {
+			continue
+		}
+		g.loadService(path)
+	}
+}
+
+func (g *Gateway) matchRoute(method, requestPath string) (*route, string) {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+
+	method = strings.ToUpper(method)
+	candidates := g.routes[method]
+	if len(candidates) == 0 && method == http.MethodHead {
+		candidates = g.routes[http.MethodGet]
+	}
+	for _, rt := range candidates {
+		if targetPath, ok := rt.matchPath(requestPath); ok {
+			return rt, targetPath
+		}
+	}
+	return nil, ""
+}
+
+func (g *Gateway) ProxyRequest(w http.ResponseWriter, r *http.Request) error {
+	rt, targetPath := g.matchRoute(r.Method, r.URL.Path)
+	if rt == nil {
+		return ErrNoMatchingRoute
+	}
+
+	baseURL, err := url.Parse(rt.service.Address)
+	if err != nil {
+		return fmt.Errorf("invalid service address for %s: %w", rt.service.Name, err)
+	}
+
+	requestURL := &url.URL{Path: targetPath, RawQuery: r.URL.RawQuery}
+	fullURL := baseURL.ResolveReference(requestURL)
+
+	req, err := http.NewRequestWithContext(r.Context(), r.Method, fullURL.String(), r.Body)
+	if err != nil {
+		return err
+	}
+	copyHeaders(req.Header, r.Header)
+	req.Header.Set("X-Forwarded-Host", r.Host)
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		req.Header.Set("X-Forwarded-Proto", proto)
+	} else if r.TLS != nil {
+		req.Header.Set("X-Forwarded-Proto", "https")
+	} else {
+		req.Header.Set("X-Forwarded-Proto", "http")
+	}
+
+	log.Printf("[gateway] proxy %s %s -> %s", r.Method, r.URL.Path, fullURL.String())
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	copyResponseHeaders(w.Header(), resp.Header)
+	w.WriteHeader(resp.StatusCode)
+	if r.Method != http.MethodHead && resp.Body != nil {
+		if _, err := io.Copy(w, resp.Body); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g *Gateway) OpenAPIHandler(w http.ResponseWriter, r *http.Request) {
+	setCORSHeaders(w)
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	scheme := "http"
+	if forwarded := r.Header.Get("X-Forwarded-Proto"); forwarded != "" {
+		scheme = forwarded
+	} else if r.TLS != nil {
+		scheme = "https"
+	}
+	baseURL := fmt.Sprintf("%s://%s", scheme, r.Host)
+	payload, err := g.BuildOpenAPISpec(baseURL)
+	if err != nil {
+		log.Printf("[gateway] failed to build OpenAPI spec: %v", err)
+		http.Error(w, "failed to build OpenAPI spec", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(payload)
+}
+
+func (g *Gateway) ProxyHandler(w http.ResponseWriter, r *http.Request) {
+	setCORSHeaders(w)
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if err := g.ProxyRequest(w, r); err != nil {
+		if errors.Is(err, ErrNoMatchingRoute) {
+			http.Error(w, "no matching endpoint", http.StatusNotFound)
+			return
+		}
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		log.Printf("[gateway] proxy error: %v", err)
+		http.Error(w, "proxy error", http.StatusBadGateway)
+	}
+}
+
+func (g *Gateway) ServicesSnapshot() []*Service {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	out := make([]*Service, 0, len(g.services))
+	for _, svc := range g.services {
+		out = append(out, svc)
+	}
+	return out
+}
+
+func isYAMLFile(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	return ext == ".yaml" || ext == ".yml"
+}
+
+var hopHeaders = []string{
+	"Connection",
+	"Keep-Alive",
+	"Proxy-Authenticate",
+	"Proxy-Authorization",
+	"Te",
+	"Trailer",
+	"Transfer-Encoding",
+	"Upgrade",
+}
+
+func copyHeaders(dst, src http.Header) {
+	for k := range dst {
+		dst.Del(k)
+	}
+	for k, vals := range src {
+		if isHopHeader(k) {
+			continue
+		}
+		for _, v := range vals {
+			dst.Add(k, v)
+		}
+	}
+}
+
+func copyResponseHeaders(dst, src http.Header) {
+	for _, header := range hopHeaders {
+		dst.Del(header)
+	}
+	for k, vals := range src {
+		if isHopHeader(k) {
+			continue
+		}
+		for _, v := range vals {
+			dst.Add(k, v)
+		}
+	}
+}
+
+func isHopHeader(name string) bool {
+	name = http.CanonicalHeaderKey(name)
+	for _, h := range hopHeaders {
+		if http.CanonicalHeaderKey(h) == name {
+			return true
+		}
+	}
+	return false
+}
+
+func setCORSHeaders(w http.ResponseWriter) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+}

--- a/internal/gateway/openapi.go
+++ b/internal/gateway/openapi.go
@@ -1,0 +1,187 @@
+package gateway
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func (g *Gateway) BuildOpenAPISpec(baseURL string) ([]byte, error) {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+
+	spec := map[string]any{
+		"openapi": "3.1.0",
+		"info": map[string]any{
+			"title":       "Local ChatGPT Gateway",
+			"version":     "1.0.0",
+			"description": "Auto-generated OpenAPI schema for locally discovered MCP servers.",
+		},
+		"servers": []any{
+			map[string]any{"url": baseURL},
+		},
+		"paths": map[string]any{},
+	}
+
+	if len(g.services) > 0 {
+		tags := make([]any, 0, len(g.services))
+		serviceNames := make([]string, 0, len(g.services))
+		for name := range g.services {
+			serviceNames = append(serviceNames, name)
+		}
+		sort.Strings(serviceNames)
+		for _, name := range serviceNames {
+			svc := g.services[name]
+			tag := map[string]any{"name": svc.Name}
+			if svc.Description != "" {
+				tag["description"] = svc.Description
+			}
+			tags = append(tags, tag)
+		}
+		spec["tags"] = tags
+	}
+
+	paths := spec["paths"].(map[string]any)
+
+	serviceNames := make([]string, 0, len(g.services))
+	for name := range g.services {
+		serviceNames = append(serviceNames, name)
+	}
+	sort.Strings(serviceNames)
+
+	for _, name := range serviceNames {
+		svc := g.services[name]
+		for _, ep := range svc.Endpoints {
+			method := strings.ToLower(ep.Method)
+			if method == "" {
+				continue
+			}
+			pathItem, _ := paths[ep.Path].(map[string]any)
+			if pathItem == nil {
+				pathItem = make(map[string]any)
+				paths[ep.Path] = pathItem
+			}
+			summary := ep.Description
+			if summary == "" {
+				summary = fmt.Sprintf("%s %s", strings.ToUpper(method), ep.Path)
+			}
+			operation := map[string]any{
+				"summary":     summary,
+				"description": buildOperationDescription(svc, ep),
+				"tags":        []string{svc.Name},
+				"responses": map[string]any{
+					"200":     map[string]any{"description": "Successful response."},
+					"default": map[string]any{"description": "Unexpected error."},
+				},
+				"x-service-name":    svc.Name,
+				"x-service-address": svc.Address,
+			}
+			operationID := ep.OperationID
+			if operationID == "" {
+				operationID = generateOperationID(svc.Name, method, ep.Path)
+			}
+			operation["operationId"] = operationID
+
+			if len(ep.Parameters) > 0 {
+				operation["parameters"] = convertParameters(ep.Parameters)
+			}
+			if body := convertRequestBody(ep.RequestBody); body != nil {
+				operation["requestBody"] = body
+			}
+			pathItem[method] = operation
+		}
+	}
+
+	return json.MarshalIndent(spec, "", "  ")
+}
+
+func buildOperationDescription(svc *Service, ep Endpoint) string {
+	var parts []string
+	if ep.Description != "" {
+		parts = append(parts, ep.Description)
+	}
+	if svc.Description != "" {
+		parts = append(parts, fmt.Sprintf("Service description: %s", svc.Description))
+	}
+	parts = append(parts, fmt.Sprintf("Requests are proxied to %s%s", svc.Address, ep.Path))
+	return strings.Join(parts, "\n\n")
+}
+
+func convertParameters(params []Parameter) []any {
+	if len(params) == 0 {
+		return nil
+	}
+	sorted := make([]Parameter, len(params))
+	copy(sorted, params)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].In == sorted[j].In {
+			return sorted[i].Name < sorted[j].Name
+		}
+		return sorted[i].In < sorted[j].In
+	})
+	result := make([]any, 0, len(sorted))
+	for _, p := range sorted {
+		item := map[string]any{
+			"name":     p.Name,
+			"in":       p.In,
+			"required": p.Required,
+		}
+		if p.Description != "" {
+			item["description"] = p.Description
+		}
+		if len(p.Schema) > 0 {
+			item["schema"] = p.Schema
+		}
+		result = append(result, item)
+	}
+	return result
+}
+
+func convertRequestBody(rb *RequestBody) map[string]any {
+	if rb == nil {
+		return nil
+	}
+	content := make(map[string]any)
+	for mediaType, def := range rb.Content {
+		if def.Schema == nil && def.Example == nil {
+			continue
+		}
+		media := make(map[string]any)
+		if def.Schema != nil {
+			media["schema"] = def.Schema
+		}
+		if def.Example != nil {
+			media["example"] = def.Example
+		}
+		content[mediaType] = media
+	}
+	if len(content) == 0 {
+		return nil
+	}
+	body := map[string]any{
+		"content": content,
+	}
+	if rb.Description != "" {
+		body["description"] = rb.Description
+	}
+	if rb.Required {
+		body["required"] = true
+	}
+	return body
+}
+
+func generateOperationID(serviceName, method, path string) string {
+	sanitized := strings.ReplaceAll(path, "/", "_")
+	sanitized = strings.ReplaceAll(sanitized, "{", "")
+	sanitized = strings.ReplaceAll(sanitized, "}", "")
+	sanitized = strings.ReplaceAll(sanitized, "-", "_")
+	sanitized = strings.ReplaceAll(sanitized, " ", "_")
+	sanitized = strings.ReplaceAll(sanitized, ".", "_")
+	sanitized = strings.ReplaceAll(sanitized, "__", "_")
+	sanitized = strings.Trim(sanitized, "_")
+	if sanitized == "" {
+		sanitized = "root"
+	}
+	return fmt.Sprintf("%s_%s_%s", serviceName, method, sanitized)
+}

--- a/internal/gateway/path.go
+++ b/internal/gateway/path.go
@@ -1,0 +1,106 @@
+package gateway
+
+import (
+	"fmt"
+	"strings"
+)
+
+type pathSegment struct {
+	literal string
+	isParam bool
+}
+
+func parsePathSegments(path string) ([]pathSegment, error) {
+	if path == "" {
+		return nil, fmt.Errorf("path cannot be empty")
+	}
+	if !strings.HasPrefix(path, "/") {
+		return nil, fmt.Errorf("path must start with '/' (got %q)", path)
+	}
+	trimmed := strings.Trim(path, "/")
+	if trimmed == "" {
+		return []pathSegment{}, nil
+	}
+	parts := strings.Split(trimmed, "/")
+	segments := make([]pathSegment, len(parts))
+	for i, part := range parts {
+		if part == "" {
+			return nil, fmt.Errorf("path %q contains empty segment", path)
+		}
+		if strings.Contains(part, "{") || strings.Contains(part, "}") {
+			if strings.HasPrefix(part, "{") && strings.HasSuffix(part, "}") {
+				name := strings.TrimSpace(part[1 : len(part)-1])
+				if name == "" {
+					return nil, fmt.Errorf("path %q contains empty parameter name", path)
+				}
+				segments[i] = pathSegment{literal: name, isParam: true}
+				continue
+			}
+			return nil, fmt.Errorf("path segment %q has unmatched braces", part)
+		}
+		segments[i] = pathSegment{literal: part, isParam: false}
+	}
+	return segments, nil
+}
+
+func extractPathParamNames(path string) ([]string, error) {
+	segments, err := parsePathSegments(path)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, seg := range segments {
+		if seg.isParam {
+			names = append(names, seg.literal)
+		}
+	}
+	return names, nil
+}
+
+type route struct {
+	service  *Service
+	endpoint Endpoint
+	segments []pathSegment
+}
+
+func newRoute(svc *Service, ep Endpoint) (*route, error) {
+	segments, err := parsePathSegments(ep.Path)
+	if err != nil {
+		return nil, err
+	}
+	return &route{
+		service:  svc,
+		endpoint: ep,
+		segments: segments,
+	}, nil
+}
+
+func (r *route) matchPath(requestPath string) (string, bool) {
+	trimmed := strings.Trim(requestPath, "/")
+	var parts []string
+	if trimmed == "" {
+		if len(r.segments) == 0 {
+			return "/", true
+		}
+		return "", false
+	}
+	parts = strings.Split(trimmed, "/")
+	if len(parts) != len(r.segments) {
+		return "", false
+	}
+	matched := make([]string, len(parts))
+	for i, seg := range r.segments {
+		if seg.isParam {
+			matched[i] = parts[i]
+			continue
+		}
+		if seg.literal != parts[i] {
+			return "", false
+		}
+		matched[i] = seg.literal
+	}
+	if len(matched) == 0 {
+		return "/", true
+	}
+	return "/" + strings.Join(matched, "/"), true
+}

--- a/internal/gateway/types.go
+++ b/internal/gateway/types.go
@@ -1,0 +1,157 @@
+package gateway
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Service struct {
+	Name        string     `yaml:"serviceName"`
+	Address     string     `yaml:"serviceAddress"`
+	Description string     `yaml:"description"`
+	Endpoints   []Endpoint `yaml:"endpoints"`
+	Source      string     `yaml:"-"`
+}
+
+type Endpoint struct {
+	Path        string       `yaml:"path"`
+	Method      string       `yaml:"method"`
+	Description string       `yaml:"description"`
+	OperationID string       `yaml:"operationId"`
+	Parameters  []Parameter  `yaml:"parameters"`
+	RequestBody *RequestBody `yaml:"requestBody"`
+}
+
+type Parameter struct {
+	Name        string         `yaml:"name"`
+	In          string         `yaml:"in"`
+	Required    bool           `yaml:"required"`
+	Description string         `yaml:"description"`
+	Schema      map[string]any `yaml:"schema"`
+}
+
+type RequestBody struct {
+	Description string                         `yaml:"description"`
+	Required    bool                           `yaml:"required"`
+	Content     map[string]MediaTypeDefinition `yaml:"content"`
+}
+
+type MediaTypeDefinition struct {
+	Schema  map[string]any `yaml:"schema"`
+	Example any            `yaml:"example"`
+}
+
+func LoadService(path string) (*Service, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("%s is a directory, expected a YAML file", path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var svc Service
+	if err := yaml.Unmarshal(data, &svc); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", filepath.Base(path), err)
+	}
+	svc.Source = path
+	if err := svc.normalizeAndValidate(); err != nil {
+		return nil, fmt.Errorf("invalid service definition %s: %w", filepath.Base(path), err)
+	}
+	return &svc, nil
+}
+
+func (s *Service) normalizeAndValidate() error {
+	s.Name = strings.TrimSpace(s.Name)
+	if s.Name == "" {
+		return fmt.Errorf("serviceName is required")
+	}
+	s.Address = strings.TrimSpace(s.Address)
+	if s.Address == "" {
+		return fmt.Errorf("serviceAddress is required")
+	}
+	s.Address = strings.TrimRight(s.Address, "/")
+	s.Description = strings.TrimSpace(s.Description)
+	if len(s.Endpoints) == 0 {
+		return fmt.Errorf("service must define at least one endpoint")
+	}
+	for i := range s.Endpoints {
+		ep := &s.Endpoints[i]
+		ep.Path = strings.TrimSpace(ep.Path)
+		if ep.Path == "" {
+			return fmt.Errorf("endpoint %d path is required", i)
+		}
+		if !strings.HasPrefix(ep.Path, "/") {
+			ep.Path = "/" + ep.Path
+		}
+		method := strings.ToUpper(strings.TrimSpace(ep.Method))
+		if method == "" {
+			return fmt.Errorf("endpoint %s must define a method", ep.Path)
+		}
+		ep.Method = method
+		ep.Description = strings.TrimSpace(ep.Description)
+		ep.OperationID = strings.TrimSpace(ep.OperationID)
+
+		paramsInPath, err := extractPathParamNames(ep.Path)
+		if err != nil {
+			return fmt.Errorf("endpoint %s %s has invalid path: %w", ep.Method, ep.Path, err)
+		}
+		expectedParams := make(map[string]bool, len(paramsInPath))
+		for _, name := range paramsInPath {
+			expectedParams[name] = false
+		}
+
+		for idx := range ep.Parameters {
+			p := &ep.Parameters[idx]
+			p.Name = strings.TrimSpace(p.Name)
+			if p.Name == "" {
+				return fmt.Errorf("endpoint %s %s has a parameter with an empty name", ep.Method, ep.Path)
+			}
+			inValue := strings.ToLower(strings.TrimSpace(p.In))
+			if inValue == "" {
+				if _, ok := expectedParams[p.Name]; ok {
+					inValue = "path"
+				} else {
+					inValue = "query"
+				}
+			}
+			p.In = inValue
+			if p.In == "path" {
+				p.Required = true
+				if _, ok := expectedParams[p.Name]; ok {
+					expectedParams[p.Name] = true
+				}
+			}
+			p.Description = strings.TrimSpace(p.Description)
+			if p.Schema == nil {
+				p.Schema = map[string]any{"type": "string"}
+			}
+		}
+
+		for name, found := range expectedParams {
+			if !found {
+				ep.Parameters = append(ep.Parameters, Parameter{
+					Name:     name,
+					In:       "path",
+					Required: true,
+					Schema:   map[string]any{"type": "string"},
+				})
+			}
+		}
+
+		if ep.RequestBody != nil {
+			ep.RequestBody.Description = strings.TrimSpace(ep.RequestBody.Description)
+			if len(ep.RequestBody.Content) == 0 {
+				ep.RequestBody = nil
+			}
+		}
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -1,26 +1,130 @@
 package main
 
 import (
-	"encoding/json"
+	"context"
+	"errors"
+	"flag"
 	"fmt"
 	"log"
 	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
 	"strings"
+	"syscall"
+	"time"
+
+	"chatgpt_go/internal/gateway"
 )
 
 func main() {
-	http.HandleFunc("/weather/", func(w http.ResponseWriter, r *http.Request) {
-		city := strings.TrimPrefix(r.URL.Path, "/weather/")
-		log.Printf("Weather service: GET /weather/%s", city)
+	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
 
-		data := map[string]string{
-			"city":        city,
-			"temperature": "22°C",
-			"condition":   fmt.Sprintf("Sunny in %s", strings.Title(city)),
+	defaultConfigDir := filepath.Join(".", "mcp_servers")
+	configDir := envOrDefault("CHATGPT_GATEWAY_CONFIG", defaultConfigDir)
+	addr := resolveListenAddr()
+
+	flag.StringVar(&configDir, "config", configDir, "Directory containing MCP server definitions")
+	flag.StringVar(&addr, "addr", addr, "Address for the gateway server (host:port or :port)")
+	flag.Parse()
+
+	gw, err := gateway.New(configDir)
+	if err != nil {
+		log.Fatalf("failed to initialise gateway: %v", err)
+	}
+
+	if err := gw.LoadExisting(); err != nil {
+		log.Fatalf("failed to load service definitions: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := gw.Watch(ctx); err != nil {
+		log.Fatalf("failed to start config watcher: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/openapi.json", gw.OpenAPIHandler)
+	mux.HandleFunc("/", gw.ProxyHandler)
+
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           loggingMiddleware(mux),
+		ReadHeaderTimeout: 10 * time.Second,
+		WriteTimeout:      90 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+
+	go func() {
+		services := gw.ServicesSnapshot()
+		if len(services) == 0 {
+			log.Printf("[gateway] no services detected yet. Drop MCP YAML files into %s", gw.ConfigDir())
+		} else {
+			for _, svc := range services {
+				log.Printf("[gateway] service ready: %s -> %s (%d endpoints)", svc.Name, svc.Address, len(svc.Endpoints))
+			}
 		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(data)
+		log.Printf("[gateway] listening on %s (config dir: %s)", addr, gw.ConfigDir())
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("server error: %v", err)
+		}
+	}()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	sig := <-sigCh
+	log.Printf("[gateway] received signal %s, shutting down", sig)
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer shutdownCancel()
+	cancel()
+
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		if errors.Is(err, context.Canceled) {
+			log.Printf("[gateway] shutdown cancelled: %v", err)
+		} else {
+			log.Printf("[gateway] graceful shutdown failed: %v", err)
+		}
+	} else {
+		log.Printf("[gateway] shutdown complete")
+	}
+}
+
+func envOrDefault(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func resolveListenAddr() string {
+	if addr := os.Getenv("CHATGPT_GATEWAY_ADDR"); addr != "" {
+		return addr
+	}
+	port := envOrDefault("CHATGPT_GATEWAY_PORT", "8080")
+	if !strings.Contains(port, ":") {
+		return fmt.Sprintf(":%s", port)
+	}
+	return port
+}
+
+type loggingResponseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (lrw *loggingResponseWriter) WriteHeader(statusCode int) {
+	lrw.status = statusCode
+	lrw.ResponseWriter.WriteHeader(statusCode)
+}
+
+func loggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		lrw := &loggingResponseWriter{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(lrw, r)
+		duration := time.Since(start)
+		log.Printf("[http] %s %s -> %d (%s)", r.Method, r.URL.Path, lrw.status, duration)
 	})
-	log.Println("Starting Weather Service on :9001")
-	http.ListenAndServe(":9001", nil)
 }

--- a/mcp_servers/todo.yaml
+++ b/mcp_servers/todo.yaml
@@ -1,16 +1,17 @@
 serviceName: todo
 serviceAddress: http://localhost:9002
-description: "A simple service to manage a TODO list."
+description: "A simple TODO list service."
 endpoints:
   - path: /todos
     method: GET
-    description: "Get the list of all TODO items."
+    description: "Get the list of TODO items."
     operationId: getTodos
   - path: /todos
     method: POST
     description: "Add a new TODO item."
     operationId: addTodo
     requestBody:
+      description: "The task to add to the TODO list."
       required: true
       content:
         application/json:
@@ -19,3 +20,6 @@ endpoints:
             properties:
               task:
                 type: string
+                description: "Description of the TODO item."
+            required:
+              - task

--- a/mcp_servers/weather.yaml
+++ b/mcp_servers/weather.yaml
@@ -1,6 +1,6 @@
 serviceName: weather
 serviceAddress: http://localhost:9001
-description: "A service to get the weather for a city."
+description: "A service that returns the current weather for a city."
 endpoints:
   - path: /weather/{city}
     method: GET
@@ -9,6 +9,6 @@ endpoints:
     parameters:
       - name: city
         in: path
-        required: true
+        description: "City to look up."
         schema:
           type: string


### PR DESCRIPTION
## Summary
- add a file-watching gateway that proxies to local MCP servers and exposes a merged OpenAPI schema
- implement service config parsing, path matching, and OpenAPI document generation helpers
- refresh sample MCP definitions, add example services, and update documentation

## Testing
- go build ./...
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ce61465830832d848447da6eaab6bb